### PR TITLE
Added interactive CLI for testing and debugging and updated append to allow custom text.

### DIFF
--- a/client_library.py
+++ b/client_library.py
@@ -56,10 +56,11 @@ def command_loop(client):
             break  # Exit loop after closing
         elif cmd == "help":
             print("Available commands:")
-            print("  --init     : Initialize the client and get client ID")
-            print("  --acquire  : Acquire the lock")
-            print("  --release  : Release the lock")
-            print("  --close    : Close the client connection and exit")
+            print("init     : Initialize the client and get client ID")
+            print("acquire  : Acquire the lock")
+            print("append      : Append to a file")
+            print("release  : Release the lock")
+            print("close    : Close the client connection and exit")
         elif cmd == "exit":
             print("Exiting interactive mode.")
             break

--- a/client_library.py
+++ b/client_library.py
@@ -1,6 +1,7 @@
 import grpc
 import lock_pb2
 import lock_pb2_grpc
+import argparse
 
 class LockClient:
     def __init__(self):
@@ -20,12 +21,13 @@ class LockClient:
         print(f"Lock acquired")
 
     def RPC_lock_release(self):
+        print(f"Attempting to release lock with client ID: {self.client_id}")
         request = lock_pb2.lock_args(client_id=self.client_id)
         response = self.stub.lock_release(request)
         print(f"Lock released")
 
-    def RPC_append_file(self, file):
-        request = lock_pb2.file_args(filename = file , content = bytes("TEST", 'utf-8'), client_id=self.client_id) #For test purposes
+    def RPC_append_file(self, file, content):
+        request = lock_pb2.file_args(filename = file , content = bytes(content, 'utf-8'), client_id=self.client_id) # Specify content to append
         response = self.stub.file_append(request)
         print(f"File appended/failed") #Error handling for different responses (goes for all rpc calls)
 
@@ -34,9 +36,44 @@ class LockClient:
         response = self.stub.client_close(request)
         print("Client connection closed.")
 
+# Interactive command loop for testing and debugging
+def command_loop(client):
+    print("Entering interactive mode. Type 'help' for a list of commands. Type 'exit' to quit.")
+    while True:
+        cmd = input("Enter command: ").strip().lower()
+        if cmd == "init":
+            client.RPC_init()
+        elif cmd == "acquire":
+            client.RPC_lock_acquire()
+        elif cmd == "append":
+            filename = input("Enter filename: ").strip()
+            content = input("Enter content: ").strip()
+            client.RPC_append_file(filename, content)
+        elif cmd == "release":
+            client.RPC_lock_release()
+        elif cmd == "close":
+            client.RPC_close()
+            break  # Exit loop after closing
+        elif cmd == "help":
+            print("Available commands:")
+            print("  --init     : Initialize the client and get client ID")
+            print("  --acquire  : Acquire the lock")
+            print("  --release  : Release the lock")
+            print("  --close    : Close the client connection and exit")
+        elif cmd == "exit":
+            print("Exiting interactive mode.")
+            break
+        else:
+            print(f"Unknown command: {cmd}. Type '--help' for a list of commands.")
+
+
 if __name__ == "__main__":
+    # Argument to start in interactive mode
+    parser = argparse.ArgumentParser(description="LockClient operations")
+    parser.add_argument("-i", "--interactive", action="store_true", help="Enter interactive mode")
+    args = parser.parse_args()
+
+    # Initialize client and enter command loop if interactive mode is selected
     client = LockClient()
-    client.RPC_init()
-    client.RPC_lock_acquire()
-    client.RPC_append_file(file= "file_1.txt")
-    
+    if args.interactive:
+        command_loop(client)


### PR DESCRIPTION
Pull request to merge into "filip-locking-architecture" which can then be merged into main.

* Changed `RPC_lock_acquire` in `client_library.py` to allow custom text to be appended to a file of choice.
* Created CLI for easier testing and debugging, which works like below.
  1. Open a terminal and run `python server.py` to start the server.
  2. Open a second terminal and run `python client_library.py` to start the first client. To start a second client, open a third terminal and run `python client_library.py`. Same with more clients.
  3. This will open an interative CLI. Input `init` to initialise the client, `acquire` to request to the server to acquire the lock, `append` to append to a file, `release` to release the lock, and `close` to close the interaction between the client. Input `help` to see the available commands.