### PR TITLE
Error handling in file append operation

### DIFF
--- a/client_library.py
+++ b/client_library.py
@@ -40,6 +40,8 @@ class LockClient:
     def RPC_close(self):
         request = lock_pb2.Int(rc=self.client_id)
         response = self.stub.client_close(request)
+        # Explicitly closing the gRPC channel.
+        self.channel.close()
         print("Client connection closed.")
 
 # Interactive command loop for testing and debugging

--- a/client_library.py
+++ b/client_library.py
@@ -17,8 +17,10 @@ class LockClient:
             
     def RPC_lock_acquire(self):
         request = lock_pb2.lock_args(client_id=self.client_id)
+        print(f"Waiting for lock...")
         response = self.stub.lock_acquire(request)
-        print(f"Lock acquired")
+        if response.status == lock_pb2.Status.SUCCESS:
+            print(f"Lock acquired")
 
     def RPC_lock_release(self):
         print(f"Attempting to release lock with client ID: {self.client_id}")

--- a/client_library.py
+++ b/client_library.py
@@ -29,7 +29,13 @@ class LockClient:
     def RPC_append_file(self, file, content):
         request = lock_pb2.file_args(filename = file , content = bytes(content, 'utf-8'), client_id=self.client_id) # Specify content to append
         response = self.stub.file_append(request)
-        print(f"File appended/failed") #Error handling for different responses (goes for all rpc calls)
+        if response.status == lock_pb2.Status.SUCCESS:
+            print(f"File appended")
+        elif response.status == lock_pb2.Status.LOCK_NOT_ACQUIRED:
+            print(f"Client does not have access to lock")
+        elif response.status == lock_pb2.Status.FILE_ERROR:
+            print(f"Filename does not exist")
+        #print(f"File appended/failed") #Error handling for different responses (goes for all rpc calls)
 
     def RPC_close(self):
         request = lock_pb2.Int(rc=self.client_id)

--- a/client_library.py
+++ b/client_library.py
@@ -32,7 +32,7 @@ class LockClient:
         if response.status == lock_pb2.Status.SUCCESS:
             print(f"File appended")
         elif response.status == lock_pb2.Status.LOCK_NOT_ACQUIRED:
-            print(f"Client does not have access to lock")
+            print(f"Lock not acquired")
         elif response.status == lock_pb2.Status.FILE_ERROR:
             print(f"Filename does not exist")
         #print(f"File appended/failed") #Error handling for different responses (goes for all rpc calls)

--- a/lock.proto
+++ b/lock.proto
@@ -11,7 +11,8 @@ message lock_args {
 // server return Status, we will add more in the future
 enum Status {
     SUCCESS = 0;   
-    FILE_ERROR = 1;    
+    FILE_ERROR = 1; 
+    LOCK_NOT_ACQUIRED = 2;   
 }
 
 // response struct, adjust or add any fields you want

--- a/lock.proto
+++ b/lock.proto
@@ -12,7 +12,7 @@ message lock_args {
 enum Status {
     SUCCESS = 0;   
     FILE_ERROR = 1; 
-    LOCK_NOT_ACQUIRED = 2;   
+    LOCK_NOT_ACQUIRED = 7;   
 }
 
 // response struct, adjust or add any fields you want

--- a/lock_pb2.py
+++ b/lock_pb2.py
@@ -13,7 +13,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\nlock.proto\x12\x0clock_service\"\x1e\n\tlock_args\x12\x11\n\tclient_id\x18\x01 \x01(\x05\"0\n\x08Response\x12$\n\x06status\x18\x01 \x01(\x0e\x32\x14.lock_service.Status\"A\n\tfile_args\x12\x10\n\x08\x66ilename\x18\x01 \x01(\t\x12\x0f\n\x07\x63ontent\x18\x02 \x01(\x0c\x12\x11\n\tclient_id\x18\x03 \x01(\x05\"\x11\n\x03Int\x12\n\n\x02rc\x18\x01 \x01(\x05*%\n\x06Status\x12\x0b\n\x07SUCCESS\x10\x00\x12\x0e\n\nFILE_ERROR\x10\x01\x32\xba\x02\n\x0bLockService\x12\x33\n\x0b\x63lient_init\x12\x11.lock_service.Int\x1a\x11.lock_service.Int\x12?\n\x0clock_acquire\x12\x17.lock_service.lock_args\x1a\x16.lock_service.Response\x12?\n\x0clock_release\x12\x17.lock_service.lock_args\x1a\x16.lock_service.Response\x12>\n\x0b\x66ile_append\x12\x17.lock_service.file_args\x1a\x16.lock_service.Response\x12\x34\n\x0c\x63lient_close\x12\x11.lock_service.Int\x1a\x11.lock_service.Intb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\nlock.proto\x12\x0clock_service\"\x1e\n\tlock_args\x12\x11\n\tclient_id\x18\x01 \x01(\x05\"0\n\x08Response\x12$\n\x06status\x18\x01 \x01(\x0e\x32\x14.lock_service.Status\"A\n\tfile_args\x12\x10\n\x08\x66ilename\x18\x01 \x01(\t\x12\x0f\n\x07\x63ontent\x18\x02 \x01(\x0c\x12\x11\n\tclient_id\x18\x03 \x01(\x05\"\x11\n\x03Int\x12\n\n\x02rc\x18\x01 \x01(\x05*<\n\x06Status\x12\x0b\n\x07SUCCESS\x10\x00\x12\x0e\n\nFILE_ERROR\x10\x01\x12\x15\n\x11LOCK_NOT_ACQUIRED\x10\x02\x32\xba\x02\n\x0bLockService\x12\x33\n\x0b\x63lient_init\x12\x11.lock_service.Int\x1a\x11.lock_service.Int\x12?\n\x0clock_acquire\x12\x17.lock_service.lock_args\x1a\x16.lock_service.Response\x12?\n\x0clock_release\x12\x17.lock_service.lock_args\x1a\x16.lock_service.Response\x12>\n\x0b\x66ile_append\x12\x17.lock_service.file_args\x1a\x16.lock_service.Response\x12\x34\n\x0c\x63lient_close\x12\x11.lock_service.Int\x1a\x11.lock_service.Intb\x06proto3')
 
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, globals())
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'lock_pb2', globals())
@@ -21,7 +21,7 @@ if _descriptor._USE_C_DESCRIPTORS == False:
 
   DESCRIPTOR._options = None
   _STATUS._serialized_start=196
-  _STATUS._serialized_end=233
+  _STATUS._serialized_end=256
   _LOCK_ARGS._serialized_start=28
   _LOCK_ARGS._serialized_end=58
   _RESPONSE._serialized_start=60
@@ -30,6 +30,6 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   _FILE_ARGS._serialized_end=175
   _INT._serialized_start=177
   _INT._serialized_end=194
-  _LOCKSERVICE._serialized_start=236
-  _LOCKSERVICE._serialized_end=550
+  _LOCKSERVICE._serialized_start=259
+  _LOCKSERVICE._serialized_end=573
 # @@protoc_insertion_point(module_scope)

--- a/server.py
+++ b/server.py
@@ -64,8 +64,8 @@ class LockService(lock_pb2_grpc.LockServiceServicer):
     def file_append(self, request, context):
         if self.lock_owner != request.client_id:
             print(f"Client {request.client_id} does not have access to lock")
-            return lock_pb2.Response(status=lock_pb2.Status.FILE_ERROR)
-        if request.filename not in self.files:
+            return lock_pb2.Response(status=lock_pb2.Status.LOCK_NOT_ACQUIRED)
+        elif request.filename not in self.files:
             print(f"Filename {request.filename} does not exist")
             return lock_pb2.Response(status=lock_pb2.Status.FILE_ERROR)
         print(f"Client {request.client_id} appended to file {request.filename}")


### PR DESCRIPTION
Updated the file append operation to have the following error handling:

1. If a client attempts to append and does not have the lock, it will see the message "Lock not acquired".
2. If the file doesnt exits, the client will see the message "File does not exist".
3. If the append is successful, client will see "File appended".

This involved adding LOCK_NOT_ACQUIRED status to the `lock.proto` file. This status is returned from the server to the client in case 1 above, where the client attempts to append and does not have the lock. 