### PR TITLE
Minor updates to handling packet loss

### DIFF
--- a/client_library.py
+++ b/client_library.py
@@ -3,6 +3,7 @@ import lock_pb2
 import lock_pb2_grpc
 import argparse
 import json
+from packet_loss import RetryInterceptor
 
 class LockClient:
     def __init__(self, interceptor=None):
@@ -36,7 +37,6 @@ class LockClient:
         request = lock_pb2.Int()
         # response = self.retries(max_retries=5,place=self.stub.client_init,query=request)
         response = self.stub.client_init(request)
-        print("oops")
         self.client_id = response.rc
         print(f"Successfully connected to server with client ID: {self.client_id}")
             
@@ -100,6 +100,6 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     # Initialize client and enter command loop if interactive mode is selected
-    client = LockClient()
+    client = LockClient(interceptor=RetryInterceptor())
     if args.interactive:
         command_loop(client)

--- a/lock.proto
+++ b/lock.proto
@@ -11,8 +11,7 @@ message lock_args {
 // server return Status, we will add more in the future
 enum Status {
     SUCCESS = 0;   
-    FILE_ERROR = 1;    
-    DEADLINE_EXCEEDED = 4;
+    FILE_ERROR = 1;
 }
 
 // response struct, adjust or add any fields you want


### PR DESCRIPTION
* Imported RetryInterceptor from packet_loss.py into client_library.py instead of other way around as the interceptor seems to work well.
* Adjusted how retry information is added to the metadata sent by the client to the server. So for key = “retry-attempt”, the value is just updated (+1) instead of adding another key-value pair to the metadata. 
* Added a helper function `print_metadata` so that metadata can be printed on the server side no matter the RPC call made.
* I run it by starting the server, then starting the client with `python client_library.py -i`. Then enter `init` on the client side as this is the RPC call where the packet loss is simulated in `server.py`.
* Also removed `DEADLINE_EXCEEDED` status code from `lock.proto` as this is built in to gRPC and doesn't need to be defined here.
