### PR TITLE
Case 2: Duplicated Requests

### DIFF
--- a/client_library.py
+++ b/client_library.py
@@ -38,12 +38,9 @@ class LockClient:
         request = lock_pb2.Int()
         # response = self.retries(max_retries=5,place=self.stub.client_init,query=request)
         response = self.stub.client_init(request)
-        print(f"Response from server is {response}")
-        if response.status == lock_pb2.Status.WORKING_ON_IT:
-            print("Server is still processing the request. Please try again later.")
-        elif isinstance(response, lock_pb2.Int):
-            self.client_id = response.rc
-            print(f"Successfully connected to server with client ID: {self.client_id}")
+        print("oops")
+        self.client_id = response.rc
+        print(f"Successfully connected to server with client ID: {self.client_id}")
             
     def RPC_lock_acquire(self):
         request = lock_pb2.lock_args(client_id=self.client_id)

--- a/client_library.py
+++ b/client_library.py
@@ -55,7 +55,6 @@ class LockClient:
     def RPC_append_file(self, file, content):
         request = lock_pb2.file_args(filename = file , content = bytes(content, 'utf-8'), client_id=self.client_id) # Specify content to append
         response = self.stub.file_append(request)
-        print(f"File appended/failed") #Error handling for different responses (goes for all rpc calls)
 
     def RPC_close(self):
         request = lock_pb2.Int(rc=self.client_id)

--- a/client_library.py
+++ b/client_library.py
@@ -3,7 +3,8 @@ import lock_pb2
 import lock_pb2_grpc
 import argparse
 import json
-from packet_loss import RetryInterceptor
+from middleware import RetryInterceptor
+import time
 
 class LockClient:
     def __init__(self, interceptor=None):
@@ -37,8 +38,12 @@ class LockClient:
         request = lock_pb2.Int()
         # response = self.retries(max_retries=5,place=self.stub.client_init,query=request)
         response = self.stub.client_init(request)
-        self.client_id = response.rc
-        print(f"Successfully connected to server with client ID: {self.client_id}")
+        print(f"Response from server is {response}")
+        if response.status == lock_pb2.Status.WORKING_ON_IT:
+            print("Server is still processing the request. Please try again later.")
+        elif isinstance(response, lock_pb2.Int):
+            self.client_id = response.rc
+            print(f"Successfully connected to server with client ID: {self.client_id}")
             
     def RPC_lock_acquire(self):
         request = lock_pb2.lock_args(client_id=self.client_id)

--- a/client_library.py
+++ b/client_library.py
@@ -38,8 +38,7 @@ class LockClient:
         request = lock_pb2.Int()
         # response = self.retries(max_retries=5,place=self.stub.client_init,query=request)
         response = self.stub.client_init(request)
-        print("oops")
-        self.client_id = response.rc
+        self.client_id = response.id_num
         print(f"Successfully connected to server with client ID: {self.client_id}")
             
     def RPC_lock_acquire(self):

--- a/lock.proto
+++ b/lock.proto
@@ -38,5 +38,5 @@ service LockService {
     rpc lock_acquire(lock_args) returns (Response);
     rpc lock_release(lock_args) returns (Response);
     rpc file_append(file_args) returns (Response);
-    rpc client_close(Int) returns (Int);
+    rpc client_close(Int) returns (Response);
 }

--- a/lock.proto
+++ b/lock.proto
@@ -12,11 +12,13 @@ message lock_args {
 enum Status {
     SUCCESS = 0;   
     FILE_ERROR = 1;
+    WORKING_ON_IT = 22;
 }
 
 // response struct, adjust or add any fields you want
 message Response {
     Status status = 1;
+    int32 id_num = 2;
 }
 
 // file append arguments, add any fields you want
@@ -32,7 +34,7 @@ message Int {
 }
 
 service LockService {
-    rpc client_init(Int) returns (Int);
+    rpc client_init(Int) returns (Response);
     rpc lock_acquire(lock_args) returns (Response);
     rpc lock_release(lock_args) returns (Response);
     rpc file_append(file_args) returns (Response);

--- a/lock.proto
+++ b/lock.proto
@@ -12,6 +12,7 @@ message lock_args {
 enum Status {
     SUCCESS = 0;   
     FILE_ERROR = 1;
+    LOCK_NOT_ACQUIRED = 7;
     WORKING_ON_IT = 22;
 }
 

--- a/middleware.py
+++ b/middleware.py
@@ -85,6 +85,10 @@ class RetryInterceptor(grpc.UnaryUnaryClientInterceptor):
                         # May include switching to a different server in the future.
                         raise grpc.RpcError("Max attempts reached")
                     
+                if actual_response.status == lock_pb2.Status.LOCK_NOT_ACQUIRED:
+                    print(f"Lock not acquired, must acquire lock before appending file")
+                    return response
+                    
                 # If the response is not an error or WORKING_ON_IT, return the response to the client
                 print(f"Response is not timeout error or WORKING_ON_IT, returning response to client: {actual_response}")
                 return response

--- a/server.py
+++ b/server.py
@@ -22,6 +22,31 @@ class LockService(lock_pb2_grpc.LockServiceServicer):
         self.client_counter = 0
         self.lock_owner = None
         self.files = {f'file_{i}.txt': [] for i in range(100)} #Change to however we want out files to look
+        # Cache to store the processed requests and their responses
+        self.response_cache = {}
+
+    def get_request_id(self, context):
+        '''Helper method to get request ID from client'''
+        for key, value in context.invocation_metadata():
+            if key == "request-id":
+                return value
+    
+    def return_cached_response(self, request_id, context):
+        '''Return cached response if available, otherwise return 0'''
+        return self.response_cache[request_id]
+
+    def initialise_cache(self, request_id):
+        '''Initialise cache with request_id and return 0'''
+        self.response_cache[request_id] = 0
+
+
+    def update_cache(self, request_id, response):
+        '''Store response in cache keyed by request_id'''
+            # Initialise the cache dict with key = request_id and value = 0
+            # This value will be updated when the server finishes processing the request
+            # Initalising request with empty value allows the server to recognise a repeated duplicate request
+        self.response_cache[request_id] = response
+
 
     def print_metadata(self, context):
         '''Helper method to print metadata from client'''
@@ -30,70 +55,152 @@ class LockService(lock_pb2_grpc.LockServiceServicer):
 
 
     def client_init(self, request, context):
+        print(f"Performing client initialization")
         self.print_metadata(context)
+        # Get request ID
+        request_id = self.get_request_id(context)
+        # Check if request_id is cached
+        if request_id in self.response_cache:
+            cached_response = self.return_cached_response(request_id, context)
+            print(f"Cached response found for request {request_id}. It is {cached_response}")
+            if cached_response == 0:
+                response = lock_pb2.Response(status=lock_pb2.Status.WORKING_ON_IT)
+                print(f"Returning response {response}")
+                return response
+            print(f"Returning cached response {cached_response}")
+            return cached_response
+        # If request_id is not cached, cache the response_ID, process it, cache the response and then return the response
+        print(f"No cache response found for request {request_id}. Processing request")
+        self.initialise_cache(request_id)
         with self.lock:
+            # simulate slow server
+            time.sleep(5)
             self.client_counter += 1
             client_id = self.client_counter
+        response = lock_pb2.Response(rc=client_id)
+        self.update_cache(request_id, response)
+        print(f"The updated cache is {self.response_cache}")
         # Testing packet loss
-        if random.random() < 0.7:
+        if random.random() < 0:
             print("Simulating packet loss: dropping response from server")
             # Set long time to simulate packet loss
-            time.sleep(1000)
-            
-        print(f"Client initialized with ID {client_id}")
-        return lock_pb2.Int(rc=client_id)
+            time.sleep(15)
+        print(f"Server has finished processing request {request_id}. Client ID is {client_id}")
+        print(f"Returning response {response}")
+        return response
     
     def client_close(self, request, context):
         self.print_metadata(context)
+        # Get request ID and check if request is cached
+        request_id = self.get_request_id(context)
+        cached_response = self.return_cached_response(request_id, context)
+        if cached_response:
+            return cached_response
+        # If request is not cached, process request and cache response
         with self.lock:
             if self.lock_owner == request.rc:
                 self.locked = False
                 self.condition.notify_all()
                 self.lock_owner = None
                 print(f"Lock released due to client {request.rc} closing.")
-
+        
+            response = lock_pb2.Response(status=lock_pb2.Status.SUCCESS)
+            self.cache_response(request_id, response)
             print(f"Client {request.rc} closed") #How else to close?
-            return lock_pb2.Response(status=lock_pb2.Status.SUCCESS)
+            return response
     
     def lock_acquire(self, request, context):
+        print(f"Performing lock acquisition")
         self.print_metadata(context)
+        # Get request ID and check if request is cached
+        request_id = self.get_request_id(context)
+        cached_response = self.return_cached_response(request_id, context)
+        if cached_response:
+            return cached_response
+        # If request is not cached, process request and cache response
         with self.condition:
             while self.locked:
                 print(f"Client {request.client_id} waiting for lock.")
                 self.condition.wait()
             self.locked = True
             self.lock_owner = request.client_id
+            response = lock_pb2.Response(status=lock_pb2.Status.SUCCESS)
+            self.cache_response(request_id, response)
             print(f"Lock granted to client {request.client_id}")
-            return lock_pb2.Response(status=lock_pb2.Status.SUCCESS)
+            return response
         
     def lock_release(self, request, context):
         self.print_metadata(context)
+        # Get request ID and check if request is cached
+        request_id = self.get_request_id(context)
+        cached_response = self.return_cached_response(request_id, context)
+        if cached_response:
+            return cached_response
+        # If request is not cached, process request and cache response
         with self.condition:
             if self.locked and self.lock_owner == request.client_id:
                 self.locked = False
                 self.lock_owner = None
-                print(f"Lock released by client {request.client_id}")
                 self.condition.notify_all()
-                return lock_pb2.Response(status=lock_pb2.Status.SUCCESS)
+                response = lock_pb2.Response(status=lock_pb2.Status.SUCCESS)
+                self.cache_response(request_id, response)
+                print(f"Lock released by client {request.client_id}")
+                return response
             elif not self.locked:
+                response = lock_pb2.Response(status=lock_pb2.Status.FILE_ERROR)
+                self.cache_response(request_id, response)
                 print(f"Client {request.client_id} attempted to release a lock that was not acquired.")
-                return lock_pb2.Response(status=lock_pb2.Status.FILE_ERROR) #Not a file error but all we have in proto?
+                return response #Not a file error but all we have in proto?
             else:
+                response = lock_pb2.Response(status=lock_pb2.Status.FILE_ERROR)
+                self.cache_response(request_id, response)
                 print(f"Client {request.client_id} attempted to release a lock owned by client {self.lock_owner}.")
-                return lock_pb2.Response(status=lock_pb2.Status.FILE_ERROR) #Again Not file error
+                return response #Again Not file error
     
     def file_append(self, request, context):
+        print(f"Performing file append")
         self.print_metadata(context)
+        # Get request ID and check if request is cached
+        request_id = self.get_request_id(context)
+        cached_response = self.return_cached_response(request_id, context)
+        if cached_response:
+            # Simmulating packet loss
+            print("Simulating packet loss: dropping response from server")
+            if random.random() < 0.3:
+                time.sleep(15)
+            return cached_response
+        else:
+            response = lock_pb2.Response(status=lock_pb2.Status.WORKING_ON_IT)
+            return response
+        # If request is not cached, process request and cache response
         if self.lock_owner != request.client_id:
+            response = lock_pb2.Response(status=lock_pb2.Status.FILE_ERROR)
+            self.cache_response(request_id, response)
             print(f"Client {request.client_id} does not have access to lock")
-            return lock_pb2.Response(status=lock_pb2.Status.FILE_ERROR)
+            if random.random() < 0.7:
+                print("Simulating packet loss: dropping response from server")
+                time.sleep(15)
+            return response
         if request.filename not in self.files:
+            response = lock_pb2.Response(status=lock_pb2.Status.FILE_ERROR)
+            self.cache_response(request_id, response)
             print(f"Filename {request.filename} does not exist")
-            return lock_pb2.Response(status=lock_pb2.Status.FILE_ERROR)
+            if random.random() < 0.7:
+                print("Simulating packet loss: dropping response from server")
+                time.sleep(15)
+            return response
         print(f"Client {request.client_id} appended to file {request.filename}")
         with open(request.filename, 'ab') as file:
+            # Simulating slow server
+            print(f"Simulating slow server: sleeping for 20 seconds")
+            time.sleep(20)
             file.write(request.content)
-        return lock_pb2.Response(status=lock_pb2.Status.SUCCESS)
+        response = lock_pb2.Response(status=lock_pb2.Status.SUCCESS)
+        self.cache_response(request_id, response)
+        if random.random() < 0.7:
+            print("Simulating packet loss: dropping response from server")
+            time.sleep(15)
+        return response
     
 if __name__ == "__main__":
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=100))

--- a/server.py
+++ b/server.py
@@ -36,15 +36,13 @@ class LockService(lock_pb2_grpc.LockServiceServicer):
         return self.response_cache[request_id]
 
     def initialise_cache(self, request_id):
-        '''Initialise cache with request_id and return 0'''
-        self.response_cache[request_id] = 0
+        '''Initialise cache with key = request_id and value =  0'''
+        # This value will be updated when the server finishes processing the request
+        self.response_cache[request_id] = None
 
 
     def update_cache(self, request_id, response):
         '''Store response in cache keyed by request_id'''
-            # Initialise the cache dict with key = request_id and value = 0
-            # This value will be updated when the server finishes processing the request
-            # Initalising request with empty value allows the server to recognise a repeated duplicate request
         self.response_cache[request_id] = response
 
 
@@ -54,74 +52,78 @@ class LockService(lock_pb2_grpc.LockServiceServicer):
         print(f"Received initial metadata from client: {metadata_str}")
 
 
-    def client_init(self, request, context):
-        print(f"Performing client initialization")
+    def process_request(self, context):
+        '''Process request from client to see if it has been cached etc.'''
+        # Print metadata
         self.print_metadata(context)
         # Get request ID
         request_id = self.get_request_id(context)
         # Check if request_id is cached
         if request_id in self.response_cache:
             cached_response = self.return_cached_response(request_id, context)
-            print(f"Cached response found for request {request_id}. It is {cached_response}")
-            if cached_response == 0:
+            # If the request_id is cached but its value hasnt been updated yet (i.e value is None), server is still working on request
+            if cached_response == None:
                 response = lock_pb2.Response(status=lock_pb2.Status.WORKING_ON_IT)
-                print(f"Returning response {response}")
+                print(f"Server is slow and still working on request {request_id}.")
                 return response
-            print(f"Returning cached response {cached_response}")
+            # If the request_id is cached and its value has been updated (i.e. value is not None), return the response
+            print(f"Cached response found for request {request_id}. Returning response")
             return cached_response
-        # If request_id is not cached, cache the response_ID, process it, cache the response and then return the response
+        # If request_id is not cached, initialise the cache with the request_id and set the response to None, then proceed to process the request
         print(f"No cache response found for request {request_id}. Processing request")
         self.initialise_cache(request_id)
-        print(f"Initialised cache with request {request_id} and value {self.response_cache[request_id]}")
+        return None
+
+
+    def client_init(self, request, context):
+        '''Initialise client'''
+        # Process request
+        response = self.process_request(context)
+        if response:
+            return response
+        # If there is no response ready, process the request and create a response
+        request_id = self.get_request_id(context)
         with self.lock:
-            # simulate slow server
-            print(f"Simulating slow server: sleeping for 5 seconds")
-            time.sleep(7)
+            # Simulate slow server
+            print(f"Simulating slow server")
+            time.sleep(3)
             print(f"Server finished sleeping")
+            # Process request
             self.client_counter += 1
             client_id = self.client_counter
         response = lock_pb2.Response(status= lock_pb2.Status.SUCCESS, id_num=client_id)
-        print(f"Response is {response}")
         self.update_cache(request_id, response)
-        print(f"The updated cache is {self.response_cache}")
-        # Testing packet loss
-        if random.random() < 0.9:
-            print("Simulating packet loss: dropping response from server")
-            # Set long time to simulate packet loss
-            time.sleep(15)
-        print(f"Server has finished processing request {request_id}. Client ID is {client_id}")
-        print(f"Returning response {response}")
+        print(f"Server has finished processing request {request_id}. Client ID is {client_id}, response is {response}")
         return response
     
     def client_close(self, request, context):
-        self.print_metadata(context)
-        # Get request ID and check if request is cached
+        '''Close client'''
+        # Process request
+        response = self.process_request(context)
+        if response:
+            return response
+        # If there is no response ready, process the request and create a response
         request_id = self.get_request_id(context)
-        cached_response = self.return_cached_response(request_id, context)
-        if cached_response:
-            return cached_response
-        # If request is not cached, process request and cache response
         with self.lock:
+            # If the client closing is the lock owner, release the lock
             if self.lock_owner == request.rc:
                 self.locked = False
                 self.condition.notify_all()
                 self.lock_owner = None
                 print(f"Lock released due to client {request.rc} closing.")
-        
+            # If the client closing is not the lock owner, just close the client
             response = lock_pb2.Response(status=lock_pb2.Status.SUCCESS)
-            self.cache_response(request_id, response)
+            self.update_cache(request_id, response)
             print(f"Client {request.rc} closed") #How else to close?
             return response
     
     def lock_acquire(self, request, context):
-        print(f"Performing lock acquisition")
-        self.print_metadata(context)
-        # Get request ID and check if request is cached
+        # Process request
+        response = self.process_request(context)
+        if response:
+            return response
+        # If there is no response ready, process the request and create a response
         request_id = self.get_request_id(context)
-        cached_response = self.return_cached_response(request_id, context)
-        if cached_response:
-            return cached_response
-        # If request is not cached, process request and cache response
         with self.condition:
             while self.locked:
                 print(f"Client {request.client_id} waiting for lock.")
@@ -129,81 +131,65 @@ class LockService(lock_pb2_grpc.LockServiceServicer):
             self.locked = True
             self.lock_owner = request.client_id
             response = lock_pb2.Response(status=lock_pb2.Status.SUCCESS)
-            self.cache_response(request_id, response)
+            self.update_cache(request_id, response)
             print(f"Lock granted to client {request.client_id}")
             return response
         
     def lock_release(self, request, context):
-        self.print_metadata(context)
-        # Get request ID and check if request is cached
+        # Process request
+        response = self.process_request(context)
+        if response:
+            return response
+        # If there is no response ready, process the request and create a response
         request_id = self.get_request_id(context)
-        cached_response = self.return_cached_response(request_id, context)
-        if cached_response:
-            return cached_response
-        # If request is not cached, process request and cache response
         with self.condition:
             if self.locked and self.lock_owner == request.client_id:
                 self.locked = False
                 self.lock_owner = None
                 self.condition.notify_all()
                 response = lock_pb2.Response(status=lock_pb2.Status.SUCCESS)
-                self.cache_response(request_id, response)
+                self.update_cache(request_id, response)
                 print(f"Lock released by client {request.client_id}")
                 return response
             elif not self.locked:
                 response = lock_pb2.Response(status=lock_pb2.Status.FILE_ERROR)
-                self.cache_response(request_id, response)
+                self.update_cache(request_id, response)
                 print(f"Client {request.client_id} attempted to release a lock that was not acquired.")
                 return response #Not a file error but all we have in proto?
             else:
                 response = lock_pb2.Response(status=lock_pb2.Status.FILE_ERROR)
-                self.cache_response(request_id, response)
+                self.update_cache(request_id, response)
                 print(f"Client {request.client_id} attempted to release a lock owned by client {self.lock_owner}.")
                 return response #Again Not file error
     
     def file_append(self, request, context):
-        print(f"Performing file append")
-        self.print_metadata(context)
-        # Get request ID and check if request is cached
-        request_id = self.get_request_id(context)
-        cached_response = self.return_cached_response(request_id, context)
-        if cached_response:
-            # Simmulating packet loss
-            print("Simulating packet loss: dropping response from server")
-            if random.random() < 0.3:
-                time.sleep(15)
-            return cached_response
-        else:
-            response = lock_pb2.Response(status=lock_pb2.Status.WORKING_ON_IT)
+        # Process request
+        response = self.process_request(context)
+        if response:
             return response
-        # If request is not cached, process request and cache response
+        # If there is no response ready, process the request and create a response
+        request_id = self.get_request_id(context)
         if self.lock_owner != request.client_id:
+            print(f"Simulating slow server")
+            time.sleep(7)
             response = lock_pb2.Response(status=lock_pb2.Status.FILE_ERROR)
-            self.cache_response(request_id, response)
+            self.update_cache(request_id, response)
             print(f"Client {request.client_id} does not have access to lock")
-            if random.random() < 0.7:
-                print("Simulating packet loss: dropping response from server")
-                time.sleep(15)
             return response
         if request.filename not in self.files:
+            print(f"Simulating slow server")
+            time.sleep(7)
             response = lock_pb2.Response(status=lock_pb2.Status.FILE_ERROR)
-            self.cache_response(request_id, response)
+            self.update_cache(request_id, response)
             print(f"Filename {request.filename} does not exist")
-            if random.random() < 0.7:
-                print("Simulating packet loss: dropping response from server")
-                time.sleep(15)
             return response
         print(f"Client {request.client_id} appended to file {request.filename}")
         with open(request.filename, 'ab') as file:
-            # Simulating slow server
-            print(f"Simulating slow server: sleeping for 20 seconds")
-            time.sleep(20)
+            print(f"Simulating slow server")
+            time.sleep(7)
             file.write(request.content)
         response = lock_pb2.Response(status=lock_pb2.Status.SUCCESS)
-        self.cache_response(request_id, response)
-        if random.random() < 0.7:
-            print("Simulating packet loss: dropping response from server")
-            time.sleep(15)
+        self.update_cache(request_id, response)
         return response
     
 if __name__ == "__main__":

--- a/server.py
+++ b/server.py
@@ -172,7 +172,7 @@ class LockService(lock_pb2_grpc.LockServiceServicer):
         if self.lock_owner != request.client_id:
             print(f"Simulating slow server")
             time.sleep(7)
-            response = lock_pb2.Response(status=lock_pb2.Status.FILE_ERROR)
+            response = lock_pb2.Response(status=lock_pb2.Status.LOCK_NOT_ACQUIRED)
             self.update_cache(request_id, response)
             print(f"Client {request.client_id} does not have access to lock")
             return response
@@ -183,13 +183,13 @@ class LockService(lock_pb2_grpc.LockServiceServicer):
             self.update_cache(request_id, response)
             print(f"Filename {request.filename} does not exist")
             return response
-        print(f"Client {request.client_id} appended to file {request.filename}")
         with open(request.filename, 'ab') as file:
             print(f"Simulating slow server")
             time.sleep(7)
             file.write(request.content)
         response = lock_pb2.Response(status=lock_pb2.Status.SUCCESS)
         self.update_cache(request_id, response)
+        print(f"Client {request.client_id} appended to file {request.filename}")
         return response
     
 if __name__ == "__main__":

--- a/server.py
+++ b/server.py
@@ -76,7 +76,7 @@ class LockService(lock_pb2_grpc.LockServiceServicer):
         with self.lock:
             # simulate slow server
             print(f"Simulating slow server: sleeping for 5 seconds")
-            time.sleep(30)
+            time.sleep(7)
             print(f"Server finished sleeping")
             self.client_counter += 1
             client_id = self.client_counter
@@ -85,7 +85,7 @@ class LockService(lock_pb2_grpc.LockServiceServicer):
         self.update_cache(request_id, response)
         print(f"The updated cache is {self.response_cache}")
         # Testing packet loss
-        if random.random() < 0:
+        if random.random() < 0.9:
             print("Simulating packet loss: dropping response from server")
             # Set long time to simulate packet loss
             time.sleep(15)

--- a/server.py
+++ b/server.py
@@ -84,10 +84,6 @@ class LockService(lock_pb2_grpc.LockServiceServicer):
         # If there is no response ready, process the request and create a response
         request_id = self.get_request_id(context)
         with self.lock:
-            # Simulate slow server
-            print(f"Simulating slow server")
-            time.sleep(3)
-            print(f"Server finished sleeping")
             # Process request
             self.client_counter += 1
             client_id = self.client_counter
@@ -170,22 +166,16 @@ class LockService(lock_pb2_grpc.LockServiceServicer):
         # If there is no response ready, process the request and create a response
         request_id = self.get_request_id(context)
         if self.lock_owner != request.client_id:
-            print(f"Simulating slow server")
-            time.sleep(7)
             response = lock_pb2.Response(status=lock_pb2.Status.LOCK_NOT_ACQUIRED)
             self.update_cache(request_id, response)
             print(f"Client {request.client_id} does not have access to lock")
             return response
         if request.filename not in self.files:
-            print(f"Simulating slow server")
-            time.sleep(7)
             response = lock_pb2.Response(status=lock_pb2.Status.FILE_ERROR)
             self.update_cache(request_id, response)
             print(f"Filename {request.filename} does not exist")
             return response
         with open(request.filename, 'ab') as file:
-            print(f"Simulating slow server")
-            time.sleep(7)
             file.write(request.content)
         response = lock_pb2.Response(status=lock_pb2.Status.SUCCESS)
         self.update_cache(request_id, response)

--- a/server.py
+++ b/server.py
@@ -76,7 +76,7 @@ class LockService(lock_pb2_grpc.LockServiceServicer):
         with self.lock:
             # simulate slow server
             print(f"Simulating slow server: sleeping for 5 seconds")
-            time.sleep(5)
+            time.sleep(30)
             print(f"Server finished sleeping")
             self.client_counter += 1
             client_id = self.client_counter

--- a/server.py
+++ b/server.py
@@ -72,12 +72,16 @@ class LockService(lock_pb2_grpc.LockServiceServicer):
         # If request_id is not cached, cache the response_ID, process it, cache the response and then return the response
         print(f"No cache response found for request {request_id}. Processing request")
         self.initialise_cache(request_id)
+        print(f"Initialised cache with request {request_id} and value {self.response_cache[request_id]}")
         with self.lock:
             # simulate slow server
+            print(f"Simulating slow server: sleeping for 5 seconds")
             time.sleep(5)
+            print(f"Server finished sleeping")
             self.client_counter += 1
             client_id = self.client_counter
-        response = lock_pb2.Response(rc=client_id)
+        response = lock_pb2.Response(status= lock_pb2.Status.SUCCESS, id_num=client_id)
+        print(f"Response is {response}")
         self.update_cache(request_id, response)
         print(f"The updated cache is {self.response_cache}")
         # Testing packet loss


### PR DESCRIPTION
Each request is handled only once, even if it is requested multiple times by the client. Also handles scenario where server is slow. When server is slow, it returns response to client saying it is "working on request", the client will then delay retrying once it knows the client is working on the request.

- Run as before, starting server with `python server.py` and client with `python client_library.py -i`
- Renamed packet_loss.py to middleware.py.
- In `lock.proto`, added LOCK_NOT_ACQUIRED status and WORKING_ON_IT status
  - Server will respond to client with LOCK_NOT_ACQUIRED when the client tries to edit a file when it does not have the lock
  - Server will respond WORKING_ON_IT to client when it is slow and receives a duplicate request but is still working on the request.
  - `client_init` and `client_close`operations will now get a response of a status code and an integer, instead of just an integer.
- Each request from the client will now contain a request_id in the metadata.
- The server will cache the request_id along with the response to this request.
- The process is outlined below:
- When a server receives a request from a client, it will extract the request id.
- Server will then check if request ID is in the cache. If it is not, the server will immediately write the request id as a key in the cache, with its value as “None”. The server will then proceed to process the request and update the value in the cache from None to whatever value, e.g. for `client_init`, the server will update the value from None to the client_id.
- If the request ID is in the cache, the server will check its corresponding value. If the value is None, the server will know that the request is still being processed and it has not updated the cache value yet, so will return to the client with response WORKING_ON_IT.
- If the request ID has a value that is not None, the server will respond with this value without processing the request again.
- The cache is set to be cleared every 30 minutes. Only the oldest half of the requests will be cleared from the cache.


